### PR TITLE
refactor: use 'backend only vars' in place of cookies to save user_id and session_id

### DIFF
--- a/mental_health/mental_health.py
+++ b/mental_health/mental_health.py
@@ -19,4 +19,4 @@ app = rx.App(
 #Website Pages
 app.add_page(pages.homepage, navigation.HOME_ROUTE, title="Homepage")
 app.add_page(pages.startherepage, navigation.STARTHERE_ROUTE, title="Comece Aqui")
-app.add_page(pages.chatpage, navigation.CHAT_ROUTE, title="Chat", on_load=ChatState.on_load)
+app.add_page(pages.chatpage, navigation.CHAT_ROUTE, title="Chat")

--- a/mental_health/models/session.py
+++ b/mental_health/models/session.py
@@ -5,6 +5,6 @@ from pydantic import BaseModel, Field
 
 class _Session_v0(BaseModel):
     created_at: datetime = Field(default_factory=datetime.now)
-    uuid: str
+    uuid: uuid.UUID
 
 Session = _Session_v0

--- a/mental_health/states/chat.py
+++ b/mental_health/states/chat.py
@@ -20,10 +20,6 @@ class ChatState(rx.State):
     # The current session ID.
     _session_id: str
 
-    @rx.event
-    def on_load(self):
-        self._start_new_session()
-
     async def answer(self):
         chat_bot_client = GptClient()
 


### PR DESCRIPTION
in this way everytime screen is loaded a new session is spawned, reseting the chat_history as well